### PR TITLE
Correct integration name in deploy script

### DIFF
--- a/scripts/gitlab/deploy_artifact.sh
+++ b/scripts/gitlab/deploy_artifact.sh
@@ -2,6 +2,6 @@
 
 set -ev
 
-vendor/bin/blt artifact:deploy --commit-msg "Automated commit by Azure Pipelines for Build $BUILD_BUILDID" --branch "$BUILD_SOURCEBRANCH-build" --no-interaction --verbose
+vendor/bin/blt artifact:deploy --commit-msg "Automated commit by Gitlab Pipelines for Build $BUILD_BUILDID" --branch "$BUILD_SOURCEBRANCH-build" --no-interaction --verbose
 
 set +v


### PR DESCRIPTION
The deploy_artifact script referenced Azure instead of Gitlab.  Fix in order to prevent any confusion.